### PR TITLE
This commit fixes two issues that caused the GitHub automation to fail:

### DIFF
--- a/.github/workflows/manual-automation.yml
+++ b/.github/workflows/manual-automation.yml
@@ -3,6 +3,10 @@ name: Manual TSV to GitHub Issues/Project
 on:
   workflow_dispatch:
 
+permissions:
+  issues: write
+  projects: write
+
 jobs:
   run-automation:
     runs-on: ubuntu-latest

--- a/SCRIPTS/import_issues.py
+++ b/SCRIPTS/import_issues.py
@@ -185,7 +185,7 @@ def manage_project(df, issue_title_to_number):
     item_id_to_issue_number = {}
     for title, issue_number in issue_title_to_number.items():
         print(f"Adding issue #{issue_number} to project #{project_number}")
-        item_id = os.popen(f"gh project item-add {project_number} --issue-number {issue_number}").read().strip()
+        item_id = os.popen(f"gh project item-add {project_number} --issue {issue_number}").read().strip()
         if item_id:
             item_id_to_issue_number[item_id] = issue_number
             print(f"Successfully added issue #{issue_number} as item {item_id}")


### PR DESCRIPTION
1.  **Incorrect flag in `import_issues.py`:** The `gh project item-add` command was using an incorrect flag (`--issue-number` instead of `--issue`). This has been corrected.
2.  **Insufficient permissions in GitHub Action:** The `manual-automation.yml` workflow was missing the necessary permissions to create issues and projects. A `permissions` block has been added to grant `issues: write` and `projects: write` access to the `GITHUB_TOKEN`.

These changes should allow the automation to run successfully when triggered from the GitHub Actions web interface.